### PR TITLE
rpmlint test: report warnings as failures

### DIFF
--- a/usmqe_tests/rpm/test_rpm.py
+++ b/usmqe_tests/rpm/test_rpm.py
@@ -74,13 +74,13 @@ def test_rpmlint(rpm_package):
     cp = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     LOGGER.debug("STDOUT: %s", cp.stdout)
     LOGGER.debug("STDERR: %s", cp.stderr)
+    LOGGER.debug("RCODE: %s", cp.returncode)
     # when the check fails, report the error in readable way
-    if cp.returncode != 0:
-        for line in cp.stdout.splitlines():
-            line_str = line.decode()
-            if "E: unknown-key" in line_str or line_str.startswith("1 packages"):
-                continue
-            LOGGER.failed(line_str)
+    for line in cp.stdout.splitlines():
+        line_str = line.decode()
+        if "E: unknown-key" in line_str or line_str.startswith("1 packages"):
+            continue
+        LOGGER.failed(line_str)
 
 
 @pytest.mark.parametrize("check_command", [

--- a/usmqe_tests/rpm/test_rpm.py
+++ b/usmqe_tests/rpm/test_rpm.py
@@ -75,7 +75,8 @@ def test_rpmlint(rpm_package):
     LOGGER.debug("STDOUT: %s", cp.stdout)
     LOGGER.debug("STDERR: %s", cp.stderr)
     LOGGER.debug("RCODE: %s", cp.returncode)
-    # when the check fails, report the error in readable way
+    # report every line on stdout as an error in readable way
+    # (except expected strings)
     for line in cp.stdout.splitlines():
         line_str = line.decode()
         if "E: unknown-key" in line_str or line_str.startswith("1 packages"):


### PR DESCRIPTION
Do not check only return code, but report all output lines as errors (except specified).