### PR TITLE
rpm validaiton tests: add tendrl-notifier package

### DIFF
--- a/usmqe_tests/rpm/packagelist.py
+++ b/usmqe_tests/rpm/packagelist.py
@@ -13,6 +13,7 @@ tendrl_packages = [
     "tendrl-gluster-integration",
     "tendrl-monitoring-integration",
     "tendrl-node-agent",
+    "tendrl-notifier",
     "tendrl-ui",
     ]
 


### PR DESCRIPTION
tendrl-notifier package (previously known as tendrl-alerting) will be part of the next release