### PR TITLE
Change API call for authentication tests

### DIFF
--- a/usmqe/api/tendrlapi/common.py
+++ b/usmqe/api/tendrlapi/common.py
@@ -114,7 +114,7 @@ class TendrlApi(ApiBase):
 
         Name:       "get_job_attribute",
         Method:     "GET",
-        Pattern     "jobs",
+        Pattern     "jobs/:job_id:",
 
         Args:
             job_id:     id of job

--- a/usmqe/api/tendrlapi/common.py
+++ b/usmqe/api/tendrlapi/common.py
@@ -209,6 +209,20 @@ class TendrlApi(ApiBase):
             issue=issue)
         return current_status
 
+    def jobs(self, asserts_in=None):
+        """ Jobs REST API
+        Name:        "jobs",
+        Method:      "GET",
+        Pattern:     "jobs",
+        """
+        pattern = "jobs"
+        response = requests.get(
+            pytest.config.getini("usm_api_url") + pattern,
+            auth=self._auth,)
+        self.print_req_info(response)
+        self.check_response(response, asserts_in)
+        return response.json()
+
     def ping(self, asserts_in=None):
         """ Ping REST API
         Name:        "ping",

--- a/usmqe_tests/api/others/test_authentication.py
+++ b/usmqe_tests/api/others/test_authentication.py
@@ -8,7 +8,7 @@ from usmqe.api.tendrlapi.common import TendrlApi, login, logout
 
 def test_login_valid(valid_session_credentials):
     api = TendrlApi(auth=valid_session_credentials)
-    api.flows()
+    api.jobs()
 
 
 def test_login_invalid():
@@ -20,7 +20,7 @@ def test_login_invalid():
         }
     auth = login("invalid_user", "invalid_password", asserts_in=asserts)
     api = TendrlApi(auth)
-    api.flows(asserts_in=asserts)
+    api.jobs(asserts_in=asserts)
 
 
 def test_session_unauthorized():
@@ -33,7 +33,7 @@ def test_session_unauthorized():
     # passing auth=None would result in api requests to be done without Tendrl
     # auth header
     api = TendrlApi(auth=None)
-    api.flows(asserts_in=asserts)
+    api.jobs(asserts_in=asserts)
 
 
 def test_session_invalid(invalid_session_credentials):
@@ -44,7 +44,7 @@ def test_session_invalid(invalid_session_credentials):
         "status": 401,
         }
     api = TendrlApi(auth=invalid_session_credentials)
-    api.flows(asserts_in=asserts)
+    api.jobs(asserts_in=asserts)
 
 
 def test_login_multiple_sessions():
@@ -71,11 +71,11 @@ def test_login_multiple_sessions_twisted():
     api_two = TendrlApi(auth=login(
         pytest.config.getini("usm_username"),
         pytest.config.getini("usm_password")))
-    api_one.flows()
-    api_two.flows()
+    api_one.jobs()
+    api_two.jobs()
     logout(auth=api_one._auth)
-    api_one.flows(asserts_in=asserts)
-    api_two.flows()
+    api_one.jobs(asserts_in=asserts)
+    api_two.jobs()
     logout(auth=api_two._auth)
-    api_one.flows(asserts_in=asserts)
-    api_two.flows(asserts_in=asserts)
+    api_one.jobs(asserts_in=asserts)
+    api_two.jobs(asserts_in=asserts)


### PR DESCRIPTION
- Added `jobs` API call.
- Fixed docstring for `jobs/:job_id:` API call.
- Changed `flows` API call to `jobs` API call in test_authentication.py.

`Flows` API call is [currently not working](https://github.com/Tendrl/api/issues/351) and I am not sure if it will be working in the form it worked anytime soon. I suggest to change API call on which is tested authentication to `jobs` and create issue in this repository to remove or change `Flows` API call after https://github.com/Tendrl/api/issues/351 is resolved.
Another possibility is just to wave authentication tests but I am against it as the problem with `Flows` API call is not related with authentication.