### PR TITLE
Rename config attribute

### DIFF
--- a/conf/example_usm.ini
+++ b/conf/example_usm.ini
@@ -13,4 +13,5 @@ etcd_api_url = %(usm_web_url):2379/v2/
 usm_ca_cert = conf/tendrl_ca.crt
 usm_brick_name = brick
 usm_pool_name = TestPool
+# fqdn of host inside cluster that is going to be reused in tests
 usm_cluster_member = example-usm3-gl1.usmqe.tendrl.org

--- a/conf/example_usm.ini
+++ b/conf/example_usm.ini
@@ -13,4 +13,4 @@ etcd_api_url = %(usm_web_url):2379/v2/
 usm_ca_cert = conf/tendrl_ca.crt
 usm_brick_name = brick
 usm_pool_name = TestPool
-usm_id_fqdn = example-usm3-gl1.usmqe.tendrl.org
+usm_cluster_member = example-usm3-gl1.usmqe.tendrl.org

--- a/docs/test_development.rst
+++ b/docs/test_development.rst
@@ -122,7 +122,7 @@ Files with tests example:
 Test uses fixtures for getting ``cluster`` object:
 
 * cluster_reuse_(storage_type) - fixture loads cluster ID from node defined by
-  ``usm_id_fqdn`` parameter in configuration and returns ``cluster`` object
+  ``usm_cluster_member`` parameter in configuration and returns ``cluster`` object
   which can be used for testing. Cluster should already exist and it's made by 
   ``cluster_`` or ``import_`` test. This fixture is used in most of the tests.
 

--- a/usmqe_tests/api/conftest.py
+++ b/usmqe_tests/api/conftest.py
@@ -48,7 +48,7 @@ def cluster_reuse(valid_session_credentials):
     is need to identify cluster directly by storage
     tools this function should be split.
     """
-    id_hostname = pytest.config.getini("usm_id_fqdn")
+    id_hostname = pytest.config.getini("usm_cluster_member")
     api = TendrlApi(auth=valid_session_credentials)
     clusters = api.get_cluster_list()
     clusters = [cluster for cluster in clusters

--- a/usmqe_tests/api/gluster/conftest.py
+++ b/usmqe_tests/api/gluster/conftest.py
@@ -30,10 +30,10 @@ def invalid_cluster_id(request):
 def valid_trusted_pool_reuse():
     """
     Return list of node hostname from created trusted pool with node specified
-    by usm_id_fqdn option in usm.ini.
+    by usm_cluster_member option in usm.ini.
     """
     storage = gluster.GlusterCommon()
-    return storage.get_hosts_from_trusted_pool(pytest.config.getini("usm_id_fqdn"))
+    return storage.get_hosts_from_trusted_pool(pytest.config.getini("usm_cluster_member"))
 
 
 @pytest.fixture(params=[None, "0000000000000000"])


### PR DESCRIPTION
Rename `usm_id_fqdn` config attribute to `usm_cluster_member` and add comment into `example_usm.ini`.