### PR TITLE
change tested user role to normal

### DIFF
--- a/usmqe_tests/conftest.py
+++ b/usmqe_tests/conftest.py
@@ -59,7 +59,7 @@ def logger_testcase(request):
         "name": "Tom Hardy",
         "username": "thardy",
         "email": "thardy@tendrl.org",
-        "role": "admin",
+        "role": "normal",
         "password": "pass1234",
         "password_confirmation": "pass1234",
         "email_notifications": True}])


### PR DESCRIPTION
According to:

- https://github.com/Tendrl/api/issues/298#issuecomment-332126115
- https://github.com/Tendrl/api/issues/299#issuecomment-332162108

it is not possible to remove `admin` user. By this change the tests are executed on user with role `normal` which allows user deletion.