### PR TITLE
add graphite api module

### DIFF
--- a/conf/example_usm.ini
+++ b/conf/example_usm.ini
@@ -10,6 +10,7 @@ usm_password = <password>
 usm_web_url = http://example-usm3-server.usmqe.tendrl.org
 usm_api_url = %(usm_web_url):9393/api/1.0/
 etcd_api_url = %(usm_web_url):2379/v2/
+graphite_api_url = %(usm_web_url):10080/
 usm_ca_cert = conf/tendrl_ca.crt
 usm_brick_name = brick
 usm_pool_name = TestPool

--- a/usmqe/api/graphiteapi/graphiteapi.py
+++ b/usmqe/api/graphiteapi/graphiteapi.py
@@ -18,9 +18,13 @@ class ApiCommon(ApiBase):
         """ Get required datapoints of provided Graphite target.
         Datapoints are in format:
         ``[[value, epoch-time], [value, epoch-time], ...]``
+        Datetime format used by Graphite API is described on:
+        ``https://graphite-api.readthedocs.io/en/latest/api.html#from-until``
 
         Args:
             target: id of Graphite metric.
+            from_date: datetime string from which date are records shown
+            until_date: datetime string to which date are records shown
         """
         pattern = "render/?target={}&format=json".format(target)
         if from_date:

--- a/usmqe/api/graphiteapi/graphiteapi.py
+++ b/usmqe/api/graphiteapi/graphiteapi.py
@@ -3,7 +3,6 @@
 Graphite REST API.
 """
 
-import json
 import requests
 import pytest
 from usmqe.api.base import ApiBase
@@ -31,4 +30,4 @@ class ApiCommon(ApiBase):
         response = requests.get(
             pytest.config.getini("graphite_api_url") + pattern)
         self.check_response(response)
-        return json.loads(response.json()[0]["datapoints"])
+        return response.json()[0]["datapoints"]

--- a/usmqe/api/graphiteapi/graphiteapi.py
+++ b/usmqe/api/graphiteapi/graphiteapi.py
@@ -1,0 +1,34 @@
+
+"""
+Graphite REST API.
+"""
+
+import json
+import requests
+import pytest
+from usmqe.api.base import ApiBase
+
+LOGGER = pytest.get_logger("graphiteapi", module=True)
+
+
+class ApiCommon(ApiBase):
+    """ Common methods for graphite REST API.
+    """
+
+    def get_datapoints(self, target, from_date=None, until_date=None):
+        """ Get required datapoints of provided Graphite target.
+        Datapoints are in format:
+        ``[[value, epoch-time], [value, epoch-time], ...]``
+
+        Args:
+            target: id of Graphite metric.
+        """
+        pattern = "render/?target={}&format=json".format(target)
+        if from_date:
+            pattern += "&from={}".format(from_date)
+        if until_date:
+            pattern += "&until={}".format(until_date)
+        response = requests.get(
+            pytest.config.getini("graphite_api_url") + pattern)
+        self.check_response(response)
+        return json.loads(response.json()[0]["datapoints"])


### PR DESCRIPTION
Adds module for basic graphite api handling as described in [documentation](https://graphite-api.readthedocs.io/en/latest/api.html#the-render-api-render).