### PR TITLE
Tls certificates for etcd

### DIFF
--- a/conf/example_usm.ini
+++ b/conf/example_usm.ini
@@ -9,7 +9,9 @@ usm_username = <username>
 usm_password = <password>
 usm_web_url = http://example-usm3-server.usmqe.tendrl.org
 usm_api_url = %(usm_web_url):9393/api/1.0/
-etcd_api_url = %(usm_web_url):2379/v2/
+# When etcd_api_url starts with https then tls certificates will be used.
+etcd_api_url = https://%(usm_web_url):2379/v2/
+# etcd_api_url = http://%(usm_web_url):2379/v2/
 usm_ca_cert = conf/tendrl_ca.crt
 usm_brick_name = brick
 usm_pool_name = TestPool

--- a/usmqe/api/etcdapi/etcdapi.py
+++ b/usmqe/api/etcdapi/etcdapi.py
@@ -60,11 +60,11 @@ class ApiCommon(ApiBase):
         pattern = "keys/{}".format(key)
         if pytest.config.getini("etcd_api_url")[4] == "s":
             response = requests.get(
-                    pytest.config.getini("etcd_api_url") + pattern,
-                    cert=(
-                        '/etc/pki/tls/certs/etcd.crt',
-                        '/etc/pki/tls/private/etcd.key'),
-                    verify = '/etc/pki/tls/certs/ca-usmqe.crt')
+                pytest.config.getini("etcd_api_url") + pattern,
+                cert=(
+                    '/etc/pki/tls/certs/etcd.crt',
+                    '/etc/pki/tls/private/etcd.key'),
+                verify='/etc/pki/tls/certs/ca-usmqe.crt')
         else:
             response = requests.get(pytest.config.getini("etcd_api_url") + pattern)
         self.check_response(response)

--- a/usmqe/api/etcdapi/etcdapi.py
+++ b/usmqe/api/etcdapi/etcdapi.py
@@ -46,7 +46,26 @@ class ApiCommon(ApiBase):
             job_id: id of created job
             attribute: attribute that is in given cluster
         """
-        pattern = "keys/queue/{}".format(job_id)
-        response = requests.get(pytest.config.getini("etcd_api_url") + pattern)
+        pattern = "queue/{}".format(job_id)
+        response = self.get_key_value(pattern)
+        return json.loads(response["node"]["value"])[attribute]
+
+    def get_key_value(self, key):
+        """ Get required value of a given key.
+
+        Args:
+            key: part of URI that is used in request on etcd
+        """
+
+        pattern = "keys/{}".format(key)
+        if pytest.config.getini("etcd_api_url")[4] == "s":
+            response = requests.get(
+                    pytest.config.getini("etcd_api_url") + pattern,
+                    cert=(
+                        '/etc/pki/tls/certs/etcd.crt',
+                        '/etc/pki/tls/private/etcd.key'),
+                    verify = '/etc/pki/tls/certs/ca-usmqe.crt')
+        else:
+            response = requests.get(pytest.config.getini("etcd_api_url") + pattern)
         self.check_response(response)
-        return json.loads(response.json()["node"]["value"])[attribute]
+        return response.json()

--- a/usmqe/api/etcdapi/etcdapi.py
+++ b/usmqe/api/etcdapi/etcdapi.py
@@ -58,7 +58,7 @@ class ApiCommon(ApiBase):
         """
 
         pattern = "keys/{}".format(key)
-        if pytest.config.getini("etcd_api_url")[4] == "s":
+        if pytest.config.getini("etcd_api_url").startswith("https"):
             response = requests.get(
                 pytest.config.getini("etcd_api_url") + pattern,
                 cert=(


### PR DESCRIPTION
Use certificates for etcd when tls is set:
```
/etc/pki/tls/certs/etcd.crt
/etc/pki/tls/private/etcd.key
/etc/pki/tls/certs/ca-usmqe.crt
```