### PR TITLE
Add api test for list of gluter volumes

### DIFF
--- a/usmqe/api/tendrlapi/glusterapi.py
+++ b/usmqe/api/tendrlapi/glusterapi.py
@@ -54,7 +54,7 @@ class TendrlApiGluster(TendrlApi):
         Args:
             cluster: id of cluster where will be created volume
         """
-        pattern = "{}/GetVolumeList".format(cluster)
+        pattern = "clusters/{}/volumes".format(cluster)
         response = requests.get(
             pytest.config.getini("usm_api_url") + pattern,
             auth=self._auth)

--- a/usmqe/gluster/gluster.py
+++ b/usmqe/gluster/gluster.py
@@ -112,13 +112,12 @@ class GlusterCommon(object):
 
     def get_volume_names(self):
         """
-        Returns name(s) of volume.
-        TODO specify order or some search if more volumes
+        Returns list of volume names.
         """
-        vol_name = self.run_on_node(command="volume info").findtext(
-            "./volInfo/volumes/volume/name")
-        LOGGER.debug("Volume_name: %s" % vol_name)
-        return vol_name
+        vol_names = [vn.text for vn in self.run_on_node(command="info").findall(
+            "./volInfo/volumes/volume/name")]
+        LOGGER.debug("Volume_names: %s" % vol_names)
+        return vol_names
 
     def get_hosts_from_trusted_pool(self, host):
         """

--- a/usmqe/gluster/gluster.py
+++ b/usmqe/gluster/gluster.py
@@ -114,9 +114,9 @@ class GlusterCommon(object):
         """
         Returns list of volume names.
         """
-        vol_names = [vn.text for vn in self.run_on_node(command="info").findall(
-            "./volInfo/volumes/volume/name")]
-        LOGGER.debug("Volume_names: %s" % vol_names)
+        vol_names = [vn.text for vn in self.run_on_node(command="list").findall(
+            "./volList/volume")]
+        LOGGER.debug("Volume_names: %s", vol_names)
         return vol_names
 
     def get_hosts_from_trusted_pool(self, host):

--- a/usmqe_tests/api/gluster/test_volume.py
+++ b/usmqe_tests/api/gluster/test_volume.py
@@ -3,6 +3,7 @@ REST API test suite - gluster volume
 """
 import pytest
 from usmqe.api.tendrlapi import glusterapi
+from usmqe.gluster import gluster
 
 
 LOGGER = pytest.get_logger('volume_test', module=True)
@@ -191,3 +192,49 @@ def test_delete_volume_invalid(
     api.wait_for_job_status(
             job_id,
             status="failed")
+
+
+@pytest.mark.gluster
+def test_volumes_list(
+        valid_session_credentials,
+        cluster_reuse,
+        valid_trusted_pool_reuse):
+    """@pylatest api/gluster.volumes_list
+        API-gluster: volumes_list
+        ******************************
+
+        .. test_metadata:: author dahorak@redhat.com
+
+        Description
+        ===========
+
+        List volumes for given cluster via API.
+
+        .. test_step:: 1
+
+                Connect to Tendrl API via GET request to ``APIURL/:cluster_id/volumes``
+                Where cluster_id is set to predefined value.
+
+        .. test_result:: 1
+
+                Server should return response in JSON format:
+
+                Return code should be **200** with data ``{"volumes": [{...}, ...]}``.
+                """
+
+    api = glusterapi.TendrlApiGluster(auth=valid_session_credentials)
+    glv_cmd = gluster.GlusterVolume()
+
+    # list of volumes from Tendrl api
+    t_volumes = api.get_volume_list(cluster_reuse['cluster_id'])
+    t_volume_names = [volume["name"] for volume in t_volumes["volumes"]]
+    t_volume_names.sort()
+    # list of volumes from Gluster command output
+    g_volume_names = glv_cmd.get_volume_names()
+    g_volume_names.sort()
+
+    LOGGER.info("list of volumes from Tendrl api: %s", str(t_volume_names))
+    LOGGER.info("list of volumes from gluster: %s", g_volume_names)
+    pytest.check(
+        t_volume_names == g_volume_names,
+        "List of volumes from Gluster should be the same as from Tendrl API.")


### PR DESCRIPTION
* Fix *tendrlapi/glusterapi* for gathering list of volumes.
* Fix gluster cmd api for gathering list of volumes.
* Create simple test comparing list of volumes from gluster and from tendrl api.