### PR TITLE
Remove sleep for https://github.com/Tendrl/api/issues/159

### DIFF
--- a/usmqe/web/tendrl/cluster_work.py
+++ b/usmqe/web/tendrl/cluster_work.py
@@ -6,7 +6,6 @@ Author: ltrilety
 
 import pytest
 
-from webstr.selenium.ui.support import WebDriverUtils
 from webstr.selenium.ui.exceptions import InitPageValidationError
 
 from usmqe.web.tendrl.clusters.pages import\
@@ -68,10 +67,6 @@ def post_check(driver, cluster_name, hosts, login_page=None):
     try:
         # TODO!!! navigation to all-clusters is elsewhere
         # NavMenuBars(driver).open_clusters(click_only=True)
-
-        # TODO remove following sleep
-        # sleep a while because of https://github.com/Tendrl/api/issues/159
-        WebDriverUtils.wait_a_while(90, driver)
 
         cluster_list = ClustersList(driver)
 

--- a/usmqe_tests/api/gluster/test_gluster_cluster.py
+++ b/usmqe_tests/api/gluster/test_gluster_cluster.py
@@ -115,10 +115,6 @@ def test_cluster_create_valid(
     LOGGER.debug("integration_id: %s" % integration_id)
 
     api.get_cluster_list()
-    # TODO(fbalak) remove this sleep after
-    #              https://github.com/Tendrl/api/issues/159 is resolved.
-    import time
-    time.sleep(30)
 
     imported_clusters = [x for x in api.get_cluster_list()
                          if x["integration_id"] == integration_id]


### PR DESCRIPTION
Removes sleep from api call for cluster creation and from cluster import web test.
Create cluster function will be removed in another PR.