### PR TITLE
Fix unmanage

### DIFF
--- a/usmqe_tests/api/gluster/test_gluster_cluster.py
+++ b/usmqe_tests/api/gluster/test_gluster_cluster.py
@@ -245,6 +245,7 @@ def test_cluster_unmanage_valid(
             break
         else:
             time.sleep(10)
+    assert cluster_list
     for cluster in cluster_list:
         if cluster["cluster_id"] == cluster_id:
             unmanaged_cluster = cluster

--- a/usmqe_tests/api/gluster/test_gluster_cluster.py
+++ b/usmqe_tests/api/gluster/test_gluster_cluster.py
@@ -192,6 +192,7 @@ def test_cluster_unmanage_valid(
         cluster_target_id = cluster_reuse["short_name"]
     else:
         cluster_target_id = cluster_reuse["cluster_id"]
+    # it takes 15 minutes to refresh data Host status panel
     for i in range(31):
         cluster_health = graphite_api.get_datapoints(
             target="tendrl.clusters.{}.status".format(cluster_target_id))
@@ -237,6 +238,7 @@ def test_cluster_unmanage_valid(
             Graphite contains no data related to health of tested cluster.
 
         """
+    # TODO(fbalak) remove this workaround when BZ 1589321 is resolved
     for i in range(15):
         cluster_list = tendrl_api.get_cluster_list()
         if len(cluster_list) > 0:

--- a/usmqe_tests/api/gluster/test_gluster_cluster.py
+++ b/usmqe_tests/api/gluster/test_gluster_cluster.py
@@ -192,8 +192,7 @@ def test_cluster_unmanage_valid(
         cluster_target_id = cluster_reuse["short_name"]
     else:
         cluster_target_id = cluster_reuse["cluster_id"]
-    i = 0
-    while i < 31:
+    for i in range(31):
         cluster_health = graphite_api.get_datapoints(
             target="tendrl.clusters.{}.status".format(cluster_target_id))
 
@@ -201,7 +200,6 @@ def test_cluster_unmanage_valid(
             break
         else:
             time.sleep(30)
-            i += 1
     pytest.check(
         cluster_health,
         """graphite health of cluster {}: {}
@@ -239,14 +237,12 @@ def test_cluster_unmanage_valid(
             Graphite contains no data related to health of tested cluster.
 
         """
-    i = 0
-    while i < 15:
+    for i in range(15):
         cluster_list = tendrl_api.get_cluster_list()
         if len(cluster_list) > 0:
             break
         else:
             time.sleep(10)
-            i += 1
     for cluster in cluster_list:
         if cluster["cluster_id"] == cluster_id:
             unmanaged_cluster = cluster

--- a/usmqe_tests/api/gluster/test_gluster_cluster.py
+++ b/usmqe_tests/api/gluster/test_gluster_cluster.py
@@ -187,10 +187,15 @@ def test_cluster_unmanage_valid(
         cluster_reuse["is_managed"] == "yes",
         "is_managed: {}\nThere should be ``yes``.".format(cluster_reuse["is_managed"]))
 
+    # graphite target uses short name if it is set
+    if cluster_reuse["short_name"]:
+        cluster_target_id = cluster_reuse["short_name"]
+    else:
+        cluster_target_id = cluster_reuse["cluster_id"]
     i = 0
     while i < 31:
         cluster_health = graphite_api.get_datapoints(
-            target="tendrl.clusters.{}.status".format(cluster_id))
+            target="tendrl.clusters.{}.status".format(cluster_target_id))
 
         if cluster_health:
             break
@@ -251,7 +256,7 @@ def test_cluster_unmanage_valid(
         "is_managed: {}\nThere should be ``no``.".format(unmanaged_cluster["is_managed"]))
 
     cluster_health = graphite_api.get_datapoints(
-        target="tendrl.clusters.{}.status".format(cluster_id))
+        target="tendrl.clusters.{}.status".format(cluster_target_id))
     pytest.check(
         cluster_health == [],
         """graphite health of cluster {}: `{}`

--- a/usmqe_tests/api/gluster/test_gluster_cluster.py
+++ b/usmqe_tests/api/gluster/test_gluster_cluster.py
@@ -3,6 +3,7 @@
 REST API test suite - gluster cluster
 """
 import pytest
+import time
 
 from usmqe.api.graphiteapi import graphiteapi
 from usmqe.api.tendrlapi import glusterapi
@@ -186,8 +187,16 @@ def test_cluster_unmanage_valid(
         cluster_reuse["is_managed"] == "yes",
         "is_managed: {}\nThere should be ``yes``.".format(cluster_reuse["is_managed"]))
 
-    cluster_health = graphite_api.get_datapoints(
-        target="tendrl.clusters.{}.status".format(cluster_id))
+    i = 0
+    while i < 31:
+        cluster_health = graphite_api.get_datapoints(
+            target="tendrl.clusters.{}.status".format(cluster_id))
+
+        if cluster_health:
+            break
+        else:
+            time.sleep(30)
+            i += 1
     pytest.check(
         cluster_health,
         """graphite health of cluster {}: {}
@@ -225,7 +234,15 @@ def test_cluster_unmanage_valid(
             Graphite contains no data related to health of tested cluster.
 
         """
-    for cluster in tendrl_api.get_cluster_list():
+    i = 0
+    while i < 15:
+        cluster_list = tendrl_api.get_cluster_list()
+        if len(cluster_list) > 0:
+            break
+        else:
+            time.sleep(10)
+            i += 1
+    for cluster in cluster_list:
         if cluster["cluster_id"] == cluster_id:
             unmanaged_cluster = cluster
             break


### PR DESCRIPTION
- Wait for not available data. Health status of cluster in Graphite takes 15 minutes to refresh.
- Use short name when it is set for Graphite targets.

Fixes https://github.com/usmqe/usmqe-tests/issues/152