### PR TITLE
unmanage test: fix Graphite Api main class name

### DIFF
--- a/usmqe_tests/api/gluster/test_gluster_cluster.py
+++ b/usmqe_tests/api/gluster/test_gluster_cluster.py
@@ -177,7 +177,7 @@ def test_cluster_unmanage_valid(
 
         """
     tendrl_api = glusterapi.TendrlApiGluster(auth=valid_session_credentials)
-    graphite_api = graphiteapi.ApiCommon()
+    graphite_api = graphiteapi.GraphiteApi()
 
     cluster_id = cluster_reuse["cluster_id"]
     pytest.check(


### PR DESCRIPTION
* update related to change in graphiteapi introduced by
  7ef3af06fc8a9e620d1d3ed66f0a8dddb4cbdb44
* fixing following [issue](https://usm-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/CI-usm2/job/tendrl-3-ci-usm2-test-gluster-distrep-api-import/lastCompletedBuild/testReport/usmqe_tests.api.gluster/test_gluster_cluster/test_cluster_unmanage_valid/)