### PR TITLE
update etcd api class name

### DIFF
--- a/usmqe/api/etcdapi/etcdapi.py
+++ b/usmqe/api/etcdapi/etcdapi.py
@@ -1,6 +1,6 @@
 
 """
-SkyRing REST API.
+etcd REST API.
 """
 
 import json
@@ -12,7 +12,7 @@ from usmqe.api.base import ApiBase
 LOGGER = pytest.get_logger("etcdapi", module=True)
 
 
-class ApiCommon(ApiBase):
+class EtcdApi(ApiBase):
     """ Common methods for etcd REST API.
     """
 


### PR DESCRIPTION
Fixes https://github.com/usmqe/usmqe-tests/issues/136

All api names should be fixed now, etcd api is currently not checked in any testcase.