### PR TITLE
Fix timing issues in import cluster test

### DIFF
--- a/usmqe/api/tendrlapi/common.py
+++ b/usmqe/api/tendrlapi/common.py
@@ -383,3 +383,18 @@ class TendrlApi(ApiBase):
         self.print_req_info(response)
         self.check_response(response)
         return response.json()["clusters"]
+
+    def get_cluster(self, cluster_id):
+        """ Get cluster informations
+
+        Name:        "get_cluster",
+        Method:      "GET",
+        Pattern:     "clusters/:cluster_id:",
+        """
+        pattern = "clusters/{}".format(cluster_id)
+        response = requests.get(
+            pytest.config.getini("usm_api_url") + pattern,
+            auth=self._auth)
+        self.print_req_info(response)
+        self.check_response(response)
+        return response.json()

--- a/usmqe_tests/api/conftest.py
+++ b/usmqe_tests/api/conftest.py
@@ -1,5 +1,7 @@
 # -*- coding: utf8 -*-
 
+import time
+
 import pytest
 
 from usmqe.api.tendrlapi.common import TendrlAuth, login, logout, TendrlApi
@@ -50,12 +52,15 @@ def cluster_reuse(valid_session_credentials):
     """
     id_hostname = pytest.config.getini("usm_cluster_member")
     api = TendrlApi(auth=valid_session_credentials)
-    clusters = api.get_cluster_list()
-    clusters = [cluster for cluster in clusters
-                if id_hostname in
-                [node["fqdn"] for node in cluster["nodes"]]
-                ]
-    if len(clusters) != 1:
-        raise Exception("There is not one cluster which includes node"
-                        " with FQDN == {}.".format(id_hostname))
-    return clusters[0]
+    for _ in range(12):
+        clusters = api.get_cluster_list()
+        clusters = [cluster for cluster in clusters
+                    if id_hostname in
+                    [node["fqdn"] for node in cluster["nodes"]]
+                    ]
+        if len(clusters) == 1:
+            return clusters[0]
+        time.sleep(5)
+
+    raise Exception("There is not one cluster which includes node"
+                    " with FQDN == {}.".format(id_hostname))

--- a/usmqe_tests/api/gluster/test_gluster_cluster.py
+++ b/usmqe_tests/api/gluster/test_gluster_cluster.py
@@ -51,10 +51,21 @@ def test_cluster_import_valid(valid_session_credentials, cluster_reuse, valid_tr
         """
     api = glusterapi.TendrlApiGluster(auth=valid_session_credentials)
     cluster_id = cluster_reuse["cluster_id"]
-    nodes = cluster_reuse["nodes"]
     pytest.check(
         cluster_id is not None,
         "Cluster id is: {}".format(cluster_id))
+    for _ in range(12):
+        cluster = api.get_cluster(cluster_id)
+        if len(cluster["nodes"]) == len(valid_trusted_pool_reuse):
+            break
+        time.sleep(10)
+    else:
+        pytest.check(
+            len(valid_trusted_pool_reuse) == len(cluster["nodes"]),
+            "Number of nodes from gluster trusted pool ({}) should be "
+            "the same as number of nodes in tendrl ({})".format(len(valid_trusted_pool_reuse),
+                                                                len(cluster["nodes"])))
+    nodes = cluster["nodes"]
     node_fqdns = [x["fqdn"] for x in nodes]
     pytest.check(
         set(valid_trusted_pool_reuse) == set(node_fqdns),


### PR DESCRIPTION
* Add `get_cluster(cluster_id)` method
* Fix timing issues leading to following errors:
```
E           Exception: There is not one cluster which includes node with FQDN == ci-usm2-gl1.localdomain.
```
([full log](https://usm-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/CI-usm2/job/tendrl-3-ci-usm2-test-gluster-arbiter-api-import/73/consoleFull))
