### PR TITLE
import cluster: ensure nodes are fully discovered

### DIFF
--- a/usmqe_tests/api/gluster/test_gluster_cluster.py
+++ b/usmqe_tests/api/gluster/test_gluster_cluster.py
@@ -56,7 +56,8 @@ def test_cluster_import_valid(valid_session_credentials, cluster_reuse, valid_tr
         "Cluster id is: {}".format(cluster_id))
     for _ in range(12):
         cluster = api.get_cluster(cluster_id)
-        if len(cluster["nodes"]) == len(valid_trusted_pool_reuse):
+        nodes = [node for node in cluster["nodes"] if node["fqdn"]]
+        if len(nodes) == len(valid_trusted_pool_reuse):
             break
         time.sleep(10)
     else:
@@ -65,7 +66,6 @@ def test_cluster_import_valid(valid_session_credentials, cluster_reuse, valid_tr
             "Number of nodes from gluster trusted pool ({}) should be "
             "the same as number of nodes in tendrl ({})".format(len(valid_trusted_pool_reuse),
                                                                 len(cluster["nodes"])))
-    nodes = cluster["nodes"]
     node_fqdns = [x["fqdn"] for x in nodes]
     pytest.check(
         set(valid_trusted_pool_reuse) == set(node_fqdns),


### PR DESCRIPTION
This is additional enhancement of PR https://github.com/usmqe/usmqe-tests/pull/159.
* ensure that nodes are fully discovered
* this should avoid situation, when the number of nodes is correct, but for example `fqdn` field is empty:
```
[08:22:29,444] [ FAIL     ] pytests_test:: usmqe_tests/api/gluster/test_gluster_cluster.py:74: AssumptionFailure: fqdns get from gluster trusted pool
(['ci-usm2-gl2.localdomain', 'ci-usm2-gl3.localdomain', 'ci-usm2-gl4.localdomain', 'ci-usm2-gl5.localdomain', 'ci-usm2-gl6.localdomain', 'ci-usm2-gl1.localdomain'])
should correspond with fqdns of nodes in tendrl
(['ci-usm2-gl4.localdomain', 'ci-usm2-gl5.localdomain', 'ci-usm2-gl3.localdomain', '', 'ci-usm2-gl1.localdomain', 'ci-usm2-gl2.localdomain'])
```