### PR TITLE
remove references to https://usmqe-testdoc.readthedocs.io/en/latest

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,7 +70,7 @@ Indices and tables
 * :ref:`search`
 
 .. _`Tendrl project`: http://tendrl.org/
-.. _`Tendrl Tests Documentation`: https://usmqe-testdoc.readthedocs.io/en/latest/
+.. _`Tendrl Tests Documentation`: https://github.com/usmqe/usmqe-testdoc
 .. _`usmqe-tests`: https://github.com/usmqe/usmqe-tests
 .. _`GNU GPL v3.0`: http://www.gnu.org/licenses/gpl-3.0.txt
 .. _`pytest`: http://docs.pytest.org/en/latest/index.html

--- a/docs/repository_overview.rst
+++ b/docs/repository_overview.rst
@@ -35,8 +35,6 @@ Upstream: https://github.com/usmqe/usmqe-testdoc
 Here you find description of usmqe testing strategy, environment and test
 cases.
 
-For a latest html build, see: https://usmqe-testdoc.readthedocs.io/en/latest/
-
 usmqe-setup
 ===========
 


### PR DESCRIPTION
https://usmqe-testdoc.readthedocs.io/en/latest is currently offline and it breaks our tox tests. This fixes it.