### PR TITLE
Create API test for <cluster_id>/nodes

### DIFF
--- a/usmqe/api/tendrlapi/glusterapi.py
+++ b/usmqe/api/tendrlapi/glusterapi.py
@@ -44,6 +44,24 @@ class TendrlApiGluster(TendrlApi):
             sds_version=pytest.config.getini("usm_gluster_version"),
             asserts_in=asserts_in)
 
+    def get_node_list(self, cluster):
+        """ Get list of gluster nodes specified by cluster id
+
+        Name:        "get_node_list",
+        Method:      "GET",
+        Pattern:     ":cluster_id:/nodes",
+
+        Args:
+            cluster: id of cluster where will be created volume
+        """
+        pattern = "clusters/{}/nodes".format(cluster)
+        response = requests.get(
+            pytest.config.getini("usm_api_url") + pattern,
+            auth=self._auth)
+        self.print_req_info(response)
+        self.check_response(response)
+        return response.json()
+
     def get_volume_list(self, cluster):
         """ Get list of gluster volumes specified by cluster id
 

--- a/usmqe/gluster/gluster.py
+++ b/usmqe/gluster/gluster.py
@@ -52,12 +52,12 @@ class GlusterCommon(object):
         last_error = None
         output = None
         if node is None:
-            node = usmqe.inventory.role2hosts(pytest.config.getini("usm_gluster_role"))[0]
+            node = pytest.config.getini("usm_cluster_member")
         if not node:
             raise GlusterCommandErrorException(
                 "Problem with gluster command '%s'.\n"
                 "Possible problem is no gluster-node (gluster_node list: %s)" %
-                (command, usmqe.inventory.role2hosts(pytest.config.getini("usm_gluster_role"))[0]))
+                (command, pytest.config.getini("usm_cluster_member")))
         if not executor:
             executor = self.cmd
         try:
@@ -119,11 +119,13 @@ class GlusterCommon(object):
         LOGGER.debug("Volume_names: %s", vol_names)
         return vol_names
 
-    def get_hosts_from_trusted_pool(self, host):
+    def get_hosts_from_trusted_pool(self, host=None):
         """
         Returns host names from trusted pool with given hostname.
         """
         # TODO change to right path to hostnames
+        if host is None:
+            host = pytest.config.getini("usm_cluster_member")
         hosts = self.run_on_node(node=host, command="peer status").findall(
             "./peerStatus/peer/hostnames/hostname")
         hosts = [x.text for x in hosts]

--- a/usmqe_tests/api/gluster/test_nodes.py
+++ b/usmqe_tests/api/gluster/test_nodes.py
@@ -1,0 +1,62 @@
+"""
+REST API test suite - gluster nodes
+"""
+import pytest
+from usmqe.api.tendrlapi import glusterapi
+
+
+LOGGER = pytest.get_logger('volume_nodes', module=True)
+"""@pylatest default
+Setup
+=====
+"""
+
+"""@pylatest default
+Teardown
+========
+"""
+
+
+@pytest.mark.testready
+@pytest.mark.happypath
+@pytest.mark.gluster
+def test_nodes_list(
+        valid_session_credentials,
+        cluster_reuse,
+        valid_trusted_pool_reuse):
+    """@pylatest api/gluster.nodes_list
+        API-gluster: nodes_list
+        ******************************
+
+        .. test_metadata:: author dahorak@redhat.com
+
+        Description
+        ===========
+
+        List nodes for given cluster via API.
+
+        .. test_step:: 1
+
+                Connect to Tendrl API via GET request to ``APIURL/:cluster_id/nodes``
+                Where cluster_id is set to predefined value.
+
+        .. test_result:: 1
+
+                Server should return response in JSON format:
+
+                Return code should be **200** with data ``{"nodes": [{...}, ...]}``.
+                """
+
+    api = glusterapi.TendrlApiGluster(auth=valid_session_credentials)
+
+    # list of nodes from Tendrl api
+    t_nodes = api.get_node_list(cluster_reuse['cluster_id'])
+    t_node_names = {node["fqdn"] for node in t_nodes["nodes"]}
+    # list of nodes from Gluster command output
+    g_node_names = set(valid_trusted_pool_reuse)
+
+    LOGGER.info("list of nodes from Tendrl api: %s", str(t_node_names))
+    LOGGER.info("list of nodes from gluster: %s", g_node_names)
+    pytest.check(
+        t_node_names == g_node_names,
+        "List of nodes from Gluster should be the same as from Tendrl API.")


### PR DESCRIPTION
This test only compare list of nodes from API call `<cluster_id>/nodes` and from `gluster peer status` command.