### PR TITLE
Add user boundary data

### DIFF
--- a/usmqe_tests/api/others/test_user.py
+++ b/usmqe_tests/api/others/test_user.py
@@ -395,7 +395,11 @@ def test_delete_admin(valid_session_credentials):
 
 @pytest.mark.happypath
 @pytest.mark.testready
-def test_user_add_del(valid_session_credentials, valid_normal_user_data):
+def test_user_add_del(
+        valid_session_credentials,
+        valid_normal_user_data,
+        valid_username,
+        valid_password):
     """@pylatest api/user.add_delete
     API-users: add and delete
     *************************
@@ -407,6 +411,8 @@ def test_user_add_del(valid_session_credentials, valid_normal_user_data):
 
     Add and remove *test* user.
     """
+    valid_normal_user_data["username"] = valid_username
+    valid_normal_user_data["password"] = valid_password
     test = tendrlapi_user.ApiUser(auth=valid_session_credentials)
     """@pylatest api/user.add_delete
     .. test_step:: 2

--- a/usmqe_tests/conftest.py
+++ b/usmqe_tests/conftest.py
@@ -188,7 +188,9 @@ def valid_new_normal_user(valid_normal_user_data):
 
 
 @pytest.fixture(params=[
-        "new_password_123"
+        "new_password_123",
+        "123456789",
+        "a" * 128,
         ])
 def valid_password(request):
     """

--- a/usmqe_tests/conftest.py
+++ b/usmqe_tests/conftest.py
@@ -214,6 +214,19 @@ def invalid_password(request):
 
 
 @pytest.fixture(params=[
+        "wee4",
+        "a2345678901234567890",
+        ])
+def valid_username(request):
+    """
+    Return valid username string.
+    Password length requirements are described here:
+    https://bugzilla.redhat.com/show_bug.cgi?id=1610913
+    """
+    return request.param
+
+
+@pytest.fixture(params=[
         "wee",
         "toolong" + "a" * 14,
         "a23456789012345678901",

--- a/usmqe_tests/conftest.py
+++ b/usmqe_tests/conftest.py
@@ -200,7 +200,7 @@ def valid_password(request):
 @pytest.fixture(params=[
         "a",
         "tooshort",
-        "toolong" + "a" * 128,
+        "a" * 129,
         ])
 def invalid_password(request):
     """
@@ -214,6 +214,7 @@ def invalid_password(request):
 @pytest.fixture(params=[
         "wee",
         "toolong" + "a" * 14,
+        "a23456789012345678901",
         ])
 def invalid_username(request):
     """


### PR DESCRIPTION
Make sure that there are tested boundary values for passwords and usernames as defined in https://bugzilla.redhat.com/show_bug.cgi?id=1610947.