### PR TITLE
drop references to deprecated testdoc repo

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,9 +14,6 @@ This documentation provides all details needed for setting up and running
 automated integration tests, as well as instruction for test automation
 development.
 
-For a description of testing strategy and test cases itself, see `Tendrl Tests
-Documentation`_ instead.
-
 
 Contents
 ========
@@ -70,7 +67,6 @@ Indices and tables
 * :ref:`search`
 
 .. _`Tendrl project`: http://tendrl.org/
-.. _`Tendrl Tests Documentation`: https://github.com/usmqe/usmqe-testdoc
 .. _`usmqe-tests`: https://github.com/usmqe/usmqe-tests
 .. _`GNU GPL v3.0`: http://www.gnu.org/licenses/gpl-3.0.txt
 .. _`pytest`: http://docs.pytest.org/en/latest/index.html

--- a/docs/repository_overview.rst
+++ b/docs/repository_overview.rst
@@ -28,14 +28,6 @@ In the root dir of the repository, there are also:
 * ``tox.ini`` and ``setup.py`` (for testing the usmqe module itself, see
   :ref:`unit-tests-label` for details)
 
-usmqe-testdoc
-=============
-
-Upstream: https://github.com/usmqe/usmqe-testdoc
-
-Here you find description of usmqe testing strategy, environment and test
-cases.
-
 usmqe-setup
 ===========
 


### PR DESCRIPTION
Drop references to deprecated testdoc repo, which is no longer maintained upstream.