### PR TITLE
Host status test

### DIFF
--- a/usmqe/api/grafanaapi/grafanaapi.py
+++ b/usmqe/api/grafanaapi/grafanaapi.py
@@ -68,13 +68,18 @@ class GrafanaApi(ApiBase):
         if panel_type:
             found_panels = [
                 panel for panel in panels
-                if "title" in panel and
-                panel["title"] == panel_title and panel["type"] == panel_type]
+                if ("title" in panel and
+                    panel["title"] == panel_title
+                    or "displayName" in panel and
+                    panel["displayName"] == panel_title)
+                and panel["type"] == panel_type]
         else:
             found_panels = [
                 panel for panel in panels
                 if "title" in panel and
-                panel["title"] == panel_title]
+                panel["title"] == panel_title
+                or "displayName" in panel and
+                panel["displayName"] == panel_title]
         assert len(found_panels) == 1
         return found_panels[0]
 

--- a/usmqe/api/grafanaapi/grafanaapi.py
+++ b/usmqe/api/grafanaapi/grafanaapi.py
@@ -66,7 +66,9 @@ class GrafanaApi(ApiBase):
         found_panels = [
             panel for panel in panels
             if "title" in panel and
-            panel["title"] == panel_title]
+            panel["title"] == panel_title
+            or "displayName" in panel and
+            panel["displayName"] == panel_title]
         assert len(found_panels) == 1
         return found_panels[0]
 

--- a/usmqe/api/graphiteapi/graphiteapi.py
+++ b/usmqe/api/graphiteapi/graphiteapi.py
@@ -52,7 +52,8 @@ class GraphiteApi(ApiBase):
             until_date=None,
             divergence=10,
             sample_rate=1,
-            operation='sum'):
+            operation='sum',
+            issue=None):
         """
         Compare expected result with sum of means from graphite data from given targets.
 
@@ -67,6 +68,7 @@ class GraphiteApi(ApiBase):
                 when there are more targets available:
                 sum - summation of data
                 diff - subtraction of data
+            issue (str): known issue, log WAIVE
         """
         graphite_data_mean_all = 0
         if from_date and not isinstance(from_date, int):
@@ -91,7 +93,8 @@ class GraphiteApi(ApiBase):
                     (len(graphite_data) == expected_number_of_datapoints) or
                     (len(graphite_data) == expected_number_of_datapoints - 1),
                     "Number of samples of used data should be {}, is {}.".format(
-                        expected_number_of_datapoints, len(graphite_data)))
+                        expected_number_of_datapoints, len(graphite_data)),
+                    issue=issue)
             LOGGER.debug("mean of data from `{}` in Graphite: {}".format(
                 target, graphite_data_mean))
             if operation == 'sum' or idx == 0:
@@ -106,11 +109,14 @@ class GraphiteApi(ApiBase):
         LOGGER.info("used operation: {}".format(operation))
         minimal_expected_result = expected_result - divergence
         maximal_expected_result = expected_result + divergence
-        msg = "Data mean should be {}, data mean in Graphite is: {}, ".format(
-            expected_result,
-            graphite_data_mean_all)
+        msg = "Data mean for target {}, "\
+              "should be {}, data mean in Graphite is: {}, ".format(
+                target,
+                expected_result,
+                graphite_data_mean_all)
         msg += "applicable divergence is {}".format(divergence)
         pytest.check(
             minimal_expected_result <=
             graphite_data_mean_all <= maximal_expected_result,
-            msg)
+            msg,
+            issue=issue)

--- a/usmqe/api/graphiteapi/graphiteapi.py
+++ b/usmqe/api/graphiteapi/graphiteapi.py
@@ -99,6 +99,6 @@ class GraphiteApi(ApiBase):
             graphite_data_mean_sum)
         msg += "applicable divergence is {}".format(divergence)
         pytest.check(
-            minimal_expected_result <
-            graphite_data_mean_sum < maximal_expected_result,
+            minimal_expected_result <=
+            graphite_data_mean_sum <= maximal_expected_result,
             msg)

--- a/usmqe/api/graphiteapi/graphiteapi.py
+++ b/usmqe/api/graphiteapi/graphiteapi.py
@@ -73,7 +73,7 @@ class GraphiteApi(ApiBase):
             graphite_data = self.get_datapoints(
                 target, from_date=from_date, until_date=until_date)
             # drop empty data points
-            graphite_data = [x for x in graphite_data if x[0]]
+            graphite_data = [x for x in graphite_data if x[0] is not None]
             # process data from graphite
             graphite_data_mean = sum(
                 [x[0] for x in graphite_data]) / max(

--- a/usmqe/api/graphiteapi/graphiteapi.py
+++ b/usmqe/api/graphiteapi/graphiteapi.py
@@ -97,7 +97,6 @@ class GraphiteApi(ApiBase):
         msg = "Data mean should be {}, data mean in Graphite is: {}, ".format(
             expected_result,
             graphite_data_mean_sum)
-        print(type(msg))
         msg += "applicable divergence is {}".format(divergence)
         pytest.check(
             minimal_expected_result <

--- a/usmqe_tests/api/grafana/test_cluster_dashboard.py
+++ b/usmqe_tests/api/grafana/test_cluster_dashboard.py
@@ -213,6 +213,7 @@ def test_hosts_panel_status(cluster_reuse):
 
 
 @pytest.mark.ansible_playbook_setup("test_setup.tendrl_services_stopped_on_nodes.yml")
+@pytest.mark.ansible_playbook_setup('test_setup.graphite_access.yml')
 @pytest.mark.ansible_playbook_teardown("test_teardown.tendrl_services_stopped_on_nodes.yml")
 @pytest.mark.author("fbalak@redhat.com")
 def test_hosts(ansible_playbook, workload_stop_nodes, cluster_reuse):
@@ -260,18 +261,18 @@ def test_hosts(ansible_playbook, workload_stop_nodes, cluster_reuse):
         (targets_used[0],),
         workload_stop_nodes["start"],
         workload_stop_nodes["end"],
-        divergence=0)
+        divergence=1)
     # check value *Up* of hosts
     graphite.compare_data_mean(
         0.0,
         (targets_used[1],),
         workload_stop_nodes["start"],
         workload_stop_nodes["end"],
-        divergence=0)
+        divergence=1)
     # check value *Down* of hosts
     graphite.compare_data_mean(
         workload_stop_nodes["result"],
         (targets_used[2],),
         workload_stop_nodes["start"],
         workload_stop_nodes["end"],
-        divergence=0)
+        divergence=1)

--- a/usmqe_tests/api/grafana/test_cluster_dashboard.py
+++ b/usmqe_tests/api/grafana/test_cluster_dashboard.py
@@ -214,6 +214,7 @@ def test_hosts_panel_status(ansible_playbook, cluster_reuse):
             g_down, len(real_down)))
 
 
+@pytest.mark.testready
 @pytest.mark.ansible_playbook_setup("test_setup.tendrl_services_stopped_on_nodes.yml")
 @pytest.mark.ansible_playbook_setup('test_setup.graphite_access.yml')
 @pytest.mark.ansible_playbook_teardown("test_teardown.tendrl_services_stopped_on_nodes.yml")

--- a/usmqe_tests/api/grafana/test_cluster_dashboard.py
+++ b/usmqe_tests/api/grafana/test_cluster_dashboard.py
@@ -253,7 +253,7 @@ def test_hosts(ansible_playbook, workload_stop_nodes, cluster_reuse):
             "There is used target that ends with `{}`".format(
                 targets_expected[idx]))
     # make sure that all data in graphite are saved
-    time.sleep(20)
+    time.sleep(3)
     # check value *Total* of hosts
     graphite.compare_data_mean(
         workload_stop_nodes["result"],

--- a/usmqe_tests/api/grafana/test_cluster_dashboard.py
+++ b/usmqe_tests/api/grafana/test_cluster_dashboard.py
@@ -263,18 +263,21 @@ def test_hosts(ansible_playbook, workload_stop_nodes, cluster_reuse):
         (targets_used[0],),
         workload_stop_nodes["start"],
         workload_stop_nodes["end"],
-        divergence=1)
+        divergence=1,
+        issue="https://bugzilla.redhat.com/show_bug.cgi?id=1687333")
     # check value *Up* of hosts
     graphite.compare_data_mean(
         0.0,
         (targets_used[1],),
         workload_stop_nodes["start"],
         workload_stop_nodes["end"],
-        divergence=1)
+        divergence=1,
+        issue="https://bugzilla.redhat.com/show_bug.cgi?id=1687333")
     # check value *Down* of hosts
     graphite.compare_data_mean(
         workload_stop_nodes["result"],
         (targets_used[2],),
         workload_stop_nodes["start"],
         workload_stop_nodes["end"],
-        divergence=1)
+        divergence=1,
+        issue="https://bugzilla.redhat.com/show_bug.cgi?id=1687333")

--- a/usmqe_tests/api/grafana/test_cluster_dashboard.py
+++ b/usmqe_tests/api/grafana/test_cluster_dashboard.py
@@ -212,8 +212,8 @@ def test_hosts_panel_status(cluster_reuse):
             g_down, len(real_down)))
 
 
-@pytest.mark.ansible_playbook_setup("test_setup.stop_tendrl_nodes.yml")
-@pytest.mark.ansible_playbook_teardown("test_teardown.stop_tendrl_nodes.yml")
+@pytest.mark.ansible_playbook_setup("test_setup.tendrl_services_stopped_on_nodes.yml")
+@pytest.mark.ansible_playbook_teardown("test_teardown.tendrl_services_stopped_on_nodes.yml")
 @pytest.mark.author("fbalak@redhat.com")
 def test_hosts(ansible_playbook, workload_stop_nodes, cluster_reuse):
     """

--- a/usmqe_tests/conftest.py
+++ b/usmqe_tests/conftest.py
@@ -51,6 +51,8 @@ def measure_operation(operation):
     start_time = datetime.datetime.now()
     result = operation()
     end_time = datetime.datetime.now()
+    LOGGER.info("Wait 10 seconds for graphite to load dataframes")
+    time.sleep(10)
     return {
         "start": start_time,
         "end": end_time,
@@ -394,7 +396,7 @@ def workload_swap_utilization(request):
 @pytest.fixture
 def workload_stop_nodes():
     """
-    Test ran with this fixture have to have use fixture `ansible_playbook`
+    Test ran with this fixture have to use fixture `ansible_playbook`
     and markers before this fixture is called:
 
     @pytest.mark.ansible_playbook_setup("test_setup.stop_tendrl_nodes.yml")
@@ -404,10 +406,11 @@ def workload_stop_nodes():
         dict: contains information about `start` and `stop` time of wait
         procedure and as `result` is used number of nodes.
     """
-    # wait for tendrl to notice that nodes are down
-    time.sleep(240)
+    LOGGER.info("Wait for tendrl to notice that nodes are down")
+    time.sleep(280)
 
     def wait():
+        LOGGER.info("Measure time when tendrl notices that nodes are down.")
         time.sleep(120)
         return len(CONF.inventory.get_groups_dict()["gluster_servers"])
     return measure_operation(wait)

--- a/usmqe_tests/conftest.py
+++ b/usmqe_tests/conftest.py
@@ -1,6 +1,7 @@
 import configparser
 import pytest
 import datetime
+import time
 import usmqe.usmssh as usmssh
 from usmqe.usmqeconfig import UsmConfig
 
@@ -388,3 +389,22 @@ def workload_swap_utilization(request):
         SSH[host].run(teardown_cmd)
         return request.param
     return measure_operation(fill_memory)
+
+
+@pytest.fixture
+def workload_stop_nodes():
+    """
+    Test ran with this fixture have to have use fixture `ansible_playbook`
+    and markers:
+
+    @pytest.mark.ansible_playbook_setup("test_setup.stop_tendrl_nodes.yml")
+    @pytest.mark.ansible_playbook_teardown("test_teardown.stop_tendrl_nodes.yml")
+
+    Returns:
+        dict: contains information about `start` and `stop` time of wait
+        procedure and as `result` is used number of nodes.
+    """
+    def wait():
+        time.sleep(120)
+        return len(CONF.inventory.get_groups_dict()["gluster_servers"])
+    return measure_operation(wait)

--- a/usmqe_tests/conftest.py
+++ b/usmqe_tests/conftest.py
@@ -395,7 +395,7 @@ def workload_swap_utilization(request):
 def workload_stop_nodes():
     """
     Test ran with this fixture have to have use fixture `ansible_playbook`
-    and markers:
+    and markers before this fixture is called:
 
     @pytest.mark.ansible_playbook_setup("test_setup.stop_tendrl_nodes.yml")
     @pytest.mark.ansible_playbook_teardown("test_teardown.stop_tendrl_nodes.yml")
@@ -404,6 +404,9 @@ def workload_stop_nodes():
         dict: contains information about `start` and `stop` time of wait
         procedure and as `result` is used number of nodes.
     """
+    # wait for tendrl to notice that nodes are down
+    time.sleep(240)
+
     def wait():
         time.sleep(120)
         return len(CONF.inventory.get_groups_dict()["gluster_servers"])


### PR DESCRIPTION
This test now fails because tendrl takes a lot of time to notice dead nodes.

This test uses playbooks from https://github.com/usmqe/usmqe-setup/pull/224