### PR TITLE
Add setup/teardown with graphite access

### DIFF
--- a/conf/usm_example.yaml
+++ b/conf/usm_example.yaml
@@ -2,6 +2,6 @@ usmqe:
   web_url: http://example-usm1-server.usmqe.tendrl.org
   api_url: http://example-usm1-server.usmqe.tendrl.org/api/1.0/
   etcd_api_url: https://example-usm1-server.usmqe.tendrl.org:2379/v2/
-  graphite_api_url: http://example-usm1-server.usmqe.tendrl.org:10080/
+  graphite_api_url: http://example-usm1-server.usmqe.tendrl.org:60080/
   grafana_api_url: http://example-usm1-server.usmqe.tendrl.org:3000/api/
   cluster_member: example-usm1-gl1.usmqe.tendrl.org

--- a/usmqe_tests/api/gluster/test_gluster_cluster.py
+++ b/usmqe_tests/api/gluster/test_gluster_cluster.py
@@ -161,6 +161,8 @@ def test_cluster_import_invalid_uuid(valid_session_credentials, cluster_id):
 @pytest.mark.happypath
 @pytest.mark.testready
 @pytest.mark.cluster_unmanage_gluster
+@pytest.mark.ansible_playbook_setup('test_setup.graphite_access.yml')
+@pytest.mark.ansible_playbook_teardown('test_teardown.graphite_access.yml')
 def test_cluster_unmanage_valid(
         valid_session_credentials, cluster_reuse, valid_trusted_pool_reuse):
     """

--- a/usmqe_tests/api/grafana/test_cluster_dashboard.py
+++ b/usmqe_tests/api/grafana/test_cluster_dashboard.py
@@ -61,6 +61,8 @@ def test_cluster_dashboard_layout():
 
 @pytest.mark.testready
 @pytest.mark.author("fbalak@redhat.com")
+@pytest.mark.ansible_playbook_setup('test_setup.graphite_access.yml')
+@pytest.mark.ansible_playbook_teardown('test_teardown.graphite_access.yml')
 def test_hosts_panel_status(cluster_reuse):
     """
     Check that Grafana panel *Hosts* is showing correct values.

--- a/usmqe_tests/api/grafana/test_host_dashboard.py
+++ b/usmqe_tests/api/grafana/test_host_dashboard.py
@@ -61,6 +61,8 @@ def test_host_dashboard_layout():
 
 @pytest.mark.testready
 @pytest.mark.author("fbalak@redhat.com")
+@pytest.mark.ansible_playbook_setup('test_setup.graphite_access.yml')
+@pytest.mark.ansible_playbook_teardown('test_teardown.graphite_access.yml')
 def test_cpu_utilization(workload_cpu_utilization, cluster_reuse):
     """
     Check that Grafana panel *CPU Utilization* is showing correct values.
@@ -108,6 +110,8 @@ def test_cpu_utilization(workload_cpu_utilization, cluster_reuse):
 
 @pytest.mark.testready
 @pytest.mark.author("fbalak@redhat.com")
+@pytest.mark.ansible_playbook_setup('test_setup.graphite_access.yml')
+@pytest.mark.ansible_playbook_teardown('test_teardown.graphite_access.yml')
 def test_memory_utilization(workload_memory_utilization, cluster_reuse):
     """
     Check that Grafana panel *memory Utilization* is showing correct values.
@@ -161,6 +165,8 @@ def test_memory_utilization(workload_memory_utilization, cluster_reuse):
 
 @pytest.mark.testready
 @pytest.mark.author("fbalak@redhat.com")
+@pytest.mark.ansible_playbook_setup('test_setup.graphite_access.yml')
+@pytest.mark.ansible_playbook_teardown('test_teardown.graphite_access.yml')
 def test_swap_free(workload_swap_utilization, cluster_reuse):
     """
     Check that Grafana panel *Swap Free* is showing correct values.
@@ -208,6 +214,8 @@ def test_swap_free(workload_swap_utilization, cluster_reuse):
 
 @pytest.mark.testready
 @pytest.mark.author("fbalak@redhat.com")
+@pytest.mark.ansible_playbook_setup('test_setup.graphite_access.yml')
+@pytest.mark.ansible_playbook_teardown('test_teardown.graphite_access.yml')
 def test_swap_utilization(workload_swap_utilization, cluster_reuse):
     """
     Check that Grafana panel *Swap Utilization* is showing correct values.


### PR DESCRIPTION
- add test_setup.graphite_access.yml and test_teardown.graphite_access.ym to tests requiring grafana access
