### PR TITLE
WORKAROUND: specify pytest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-pytest
+# WORKAROUND for https://github.com/usmqe/usmqe-tests/issues/227
+pytest == 4.0.2
+#pytest
 pytest-ansible-playbook
 plumbum
 requests


### PR DESCRIPTION
It is not possible to run tests with new pytest 4.1.0, so specifying
older version as required.
- https://github.com/usmqe/usmqe-tests/issues/227