### PR TITLE
workaround for pytest-ansible-playbook comp. issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # WORKAROUND for https://github.com/usmqe/usmqe-tests/issues/227
-pytest == 4.0.2
-#pytest
+# pytest == 4.0.2
+# WORKAROUND for https://gitlab.com/mbukatov/pytest-ansible-playbook/issues/6#note_133366849
+pytest == 3.10.1
 pytest-ansible-playbook
 plumbum
 requests


### PR DESCRIPTION
This freezes us on even older pytest version, 3.10.1 from Nov 2018, because of compatibility issue between pytest-ansible-playbook and pytest 4.x, see:

* https://gitlab.com/mbukatov/pytest-ansible-playbook/issues/6#note_133366849
* https://docs.pytest.org/en/latest/mark.html#marker-revamp-and-iteration

Fortunately 3.10.1 is not that old.