### PR TITLE
remove testready marks from swap utilization tests

### DIFF
--- a/usmqe_tests/api/grafana/test_host_dashboard.py
+++ b/usmqe_tests/api/grafana/test_host_dashboard.py
@@ -165,7 +165,6 @@ def test_memory_utilization(
         divergence=15)
 
 
-@pytest.mark.testready
 @pytest.mark.author("fbalak@redhat.com")
 @pytest.mark.ansible_playbook_setup('test_setup.graphite_access.yml')
 @pytest.mark.ansible_playbook_teardown('test_teardown.graphite_access.yml')
@@ -215,7 +214,6 @@ def test_swap_free(
         divergence=15)
 
 
-@pytest.mark.testready
 @pytest.mark.author("fbalak@redhat.com")
 @pytest.mark.ansible_playbook_setup('test_setup.graphite_access.yml')
 @pytest.mark.ansible_playbook_teardown('test_teardown.graphite_access.yml')


### PR DESCRIPTION
Tests `test_swap_free` and `test_swap_utilization` are quite unstable, so I'm proposing to remove the `testready` flag, to remove them from main test suite for now.
- https://github.com/usmqe/usmqe-tests/issues/221
- failure example in CentOS CI: https://ci.centos.org/job/tendrl-2-3-cluster-gluster-test-api-others/449/consoleFull