### PR TITLE
script to find provisioner node

### DIFF
--- a/find_provisioner.py
+++ b/find_provisioner.py
@@ -7,6 +7,10 @@ Script to find Tendrl *provisioner* node. It requires the same setup and
 configuration as our tests executed via ``pytest_cli.py`` wrapper (eg. to
 locate, authenticate and access etcd instance).
 
+You need to run `qe_server.ssl_ca_etcd.yml` playbook to be able to access etcd
+if tls client server auth is configured (which is the default in usmqe test
+deployments).
+
 TODO: move get_nodes_by_tag() into usmqe module
 """
 

--- a/find_provisioner.py
+++ b/find_provisioner.py
@@ -15,10 +15,9 @@ import argparse
 import json
 import sys
 
-import pytest
-
 # This is a terrible HACK, overcomming lack of code reusability and
 # entanglement of code in usmqe module :/
+import pytest
 import plugin.log_assert
 def _check(*args, **kwargs):
     pass

--- a/find_provisioner.py
+++ b/find_provisioner.py
@@ -65,7 +65,7 @@ def main():
     else:
         LOGGER.setLevel("INFO")
 
-    LOGGER.info("loading UsmConfig")
+    LOGGER.debug("loading UsmConfig")
     conf = UsmConfig()
     LOGGER.info("url of etcd: %s", conf.config["usmqe"]["etcd_api_url"])
 

--- a/find_provisioner.py
+++ b/find_provisioner.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# -*- coding: utf8 -*-
+
+
+"""
+Script to find Tendrl *provisioner* node. It requires the same setup and
+configuration as our tests executed via ``pytest_cli.py`` wrapper (eg. to
+locate, authenticate and access etcd instance).
+
+TODO: move get_nodes_by_tag() into usmqe module
+"""
+
+
+import argparse
+import json
+import sys
+
+import pytest
+
+# This is a terrible HACK, overcomming lack of code reusability and
+# entanglement of code in usmqe module :/
+import plugin.log_assert
+def _check(*args, **kwargs):
+    pass
+pytest.get_logger = plugin.log_assert.get_logger
+pytest.check = _check
+
+from usmqe.api.etcdapi.etcdapi import EtcdApi
+
+
+def get_nodes_by_tag(tag):
+    """
+    Query Tendrl etcd instance for nodes with given tag.
+    """
+    etcd = EtcdApi()
+    resp = etcd.get_key_value('/indexes/tags/{}/'.format(tag))
+    # TODO: WTF? Why?
+    nodes_str_val = resp['node']['nodes'][0]['value']
+    nodes = json.loads(nodes_str_val)
+    node_names = []
+    for node_id in nodes:
+        resp = etcd.get_key_value('/nodes/{}/NodeContext/fqdn'.format(node_id))
+        node_names.append(resp['node']['value'])
+    return node_names
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Find Tendrl provisioner node(s).")
+    ap.add_argument("-v", dest="verbose", action="store_true", help="verbose")
+    args = ap.parse_args()
+
+    for node_name in get_nodes_by_tag("provisioner"):
+        print(node_name)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/usmqe/api/etcdapi/etcdapi.py
+++ b/usmqe/api/etcdapi/etcdapi.py
@@ -50,6 +50,7 @@ class EtcdApi(ApiBase):
         """
         pattern = "queue/{}".format(job_id)
         response = self.get_key_value(pattern)
+        self.print_req_info(response)
         return json.loads(response["node"]["value"])[attribute]
 
     def get_key_value(self, key):
@@ -69,5 +70,6 @@ class EtcdApi(ApiBase):
                 verify='/etc/pki/tls/certs/ca-usmqe.crt')
         else:
             response = requests.get(CONF.config["usmqe"]["etcd_api_url"] + pattern)
+        self.print_req_info(response)
         self.check_response(response)
         return response.json()

--- a/usmqe/api/etcdapi/etcdapi.py
+++ b/usmqe/api/etcdapi/etcdapi.py
@@ -65,8 +65,8 @@ class EtcdApi(ApiBase):
             response = requests.get(
                 CONF.config["usmqe"]["etcd_api_url"] + pattern,
                 cert=(
-                    '/etc/pki/tls/certs/etcd.crt',
-                    '/etc/pki/tls/private/etcd.key'),
+                    '/etc/pki/tls/certs/qeserver.crt',
+                    '/etc/pki/tls/private/qeserver.key'),
                 verify='/etc/pki/tls/certs/ca-usmqe.crt')
         else:
             response = requests.get(CONF.config["usmqe"]["etcd_api_url"] + pattern)


### PR DESCRIPTION
It's a hack, but so it somehow works:

```
[usmqe@mbukatov usmqe-tests]$ ./find_provisioner.py 
[10:54:17,754] Test run ID   : main_test
[10:54:17,754] Package       : unknown
[10:54:17,754] Test started  : 10:54:17,754717
[10:54:17,760] Hostname      : mbukatov.example.com
[10:54:17,761] Architecture  : x86_64
[10:54:17,761] Distro:       : CentOS Linux release 7.6.1810 (Core)
[10:54:17,761] :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
[10:54:18,426] [ INFO     ] main_test:: loading UsmConfig
[10:54:18,442] [ INFO     ] main_test:: url of etcd: https://mbukatov-usm2-server.example.com:2379/v2/
[10:54:18,483] [ INFO     ] main_test:: found 1 provisioner node(s)
[10:54:18,484] [ INFO     ] main_test:: mbukatov-usm2-gl5
```

You need to run this playbook for the script to work on qe server: https://github.com/usmqe/usmqe-setup/pull/235

If we need to use this functionality in test code, `EtcdApi` class needs to be polished and function `get_nodes_by_tag` moved there.