### PR TITLE
clarify cluster_reuse logs

### DIFF
--- a/usmqe_tests/conftest.py
+++ b/usmqe_tests/conftest.py
@@ -371,6 +371,13 @@ def valid_session_credentials(request):
     logout(auth=auth)
 
 
+def cluster2node_fqdn_list(cluster):
+    """
+    Returns list of fqdn of nodes which belongs to given cluster.
+    """
+    return [node["fqdn"] for node in cluster["nodes"]]
+
+
 @pytest.fixture
 def cluster_reuse(valid_session_credentials):
     """
@@ -390,16 +397,16 @@ def cluster_reuse(valid_session_credentials):
     for i in range(retry_num):
         clusters = []
         for cluster in api.get_cluster_list():
-            node_fqdn_list = [node["fqdn"] for node in cluster["nodes"]]
+            node_fqdn_list = cluster2node_fqdn_list(cluster)
             if id_hostname in node_fqdn_list:
                 clusters.append(cluster)
-                LOGGER.debug("found cluster for cluster member {}".format(id_hostname))
+                msg = "cluster member {} found in cluster {}"
             else:
                 msg = "cluster member {} not found in cluster {}"
-                LOGGER.debug(msg.format(id_hostname, node_fqdn_list))
+            LOGGER.debug(msg.format(id_hostname, node_fqdn_list))
         if len(clusters) == 1:
             cluster = clusters[0]
-            LOGGER.info("using cluster: {}".format([node["fqdn"] for node in cluster["nodes"]]))
+            LOGGER.info("using cluster: {}".format(cluster2node_fqdn_list(cluster)))
             return cluster
         else:
             LOGGER.warning("unexpected number (!= 1) of clusters found: {}".format(len(clusters)))


### PR DESCRIPTION
This pull requests improves logging of `cluster_reuse` fixture, which is important for us to be able to identify issues like BZ 1690021 or BZ 1631769 from the test run logs.

Example of logs when a cluster is found:

```
[04:55:26,994] [ DEBUG    ] cluster_reuse:: cluster member mbukatov-usm1-gl1.example.com found in cluster ['mbukatov-usm1-gl1.example.com', 'mbukatov-usm1-gl4', 'mbukatov-usm1-gl3', 'mbukatov-usm1-gl2']
[04:55:26,994] [ INFO     ] cluster_reuse:: using cluster: ['mbukatov-usm1-gl1.example.com', 'mbukatov-usm1-gl4', 'mbukatov-usm1-gl3', 'mbukatov-usm1-gl2']
```

And when the cluster is not found:

```
[04:57:25,188] [ DEBUG    ] cluster_reuse:: cluster member mbukatov-usm3-gl1.example.com not found in cluster ['mbukatov-usm1-gl4', 'mbukatov-usm1-gl3', 'mbukatov-usm1-gl2', 'mbukatov-usm1-gl1.example.com']
[04:57:25,188] [ WARNING  ] cluster_reuse:: unexpected number (!= 1) of clusters found: 0
[04:57:25,188] [ INFO     ] cluster_reuse:: retrying search for a cluster
...
[04:59:20,500] [ DEBUG    ] cluster_reuse:: cluster member mbukatov-usm3-gl1.example.com not found in cluster ['mbukatov-usm1-gl1.example.com', 'mbukatov-usm1-gl4', 'mbukatov-usm1-gl3', 'mbukatov-usm1-gl2']
[04:59:20,501] [ WARNING  ] cluster_reuse:: unexpected number (!= 1) of clusters found: 0
[04:59:20,520] [ ERROR    ] pytests_test:: Exception: There is no cluster which includes node with FQDN == mbukatov-usm3-gl1.example.com.
```