### PR TITLE
Negative import cluster test when one node agent is down

### DIFF
--- a/usmqe_tests/api/conftest.py
+++ b/usmqe_tests/api/conftest.py
@@ -1,7 +1,9 @@
 # -*- coding: utf8 -*-
 
 import pytest
+import pytest_ansible_playbook
 
+from usmqe.api.tendrlapi import glusterapi
 from usmqe.api.tendrlapi.common import TendrlAuth
 from usmqe.usmqeconfig import UsmConfig
 
@@ -25,3 +27,29 @@ def invalid_session_credentials(request):
     invalid_token = request.param
     auth = TendrlAuth(token=invalid_token, username=username)
     return auth
+
+
+@pytest.fixture
+def importfail_setup_nodeagent_stopped_on_one_node(
+        request,
+        cluster_reuse,
+        valid_session_credentials):
+    """
+    This fixture stops node agent on one storage machine. During teardown it
+    makes sure that the node agent is back and then runs unmanage job to
+    cleanup state after a failed import.
+
+    Don't use this fixture if you are not running negative test cases for
+    import cluster feature.
+    """
+    with pytest_ansible_playbook.runner(
+            request,
+            ["test_setup.tendrl_nodeagent_stopped_on_one_node.yml"],
+            ["test_teardown.tendrl_nodeagent_stopped_on_one_node.yml"]):
+        yield
+    # And now something completely different: we need to run unmanage because
+    # the cluster is not managed after a failed import, which would block any
+    # future import attempt.
+    tendrl = glusterapi.TendrlApiGluster(auth=valid_session_credentials)
+    job = tendrl.unmanage_cluster(cluster_reuse["cluster_id"])
+    tendrl.wait_for_job_status(job["job_id"])

--- a/usmqe_tests/api/gluster/test_gluster_cluster.py
+++ b/usmqe_tests/api/gluster/test_gluster_cluster.py
@@ -160,7 +160,6 @@ def test_cluster_import_invalid_uuid(valid_session_credentials, cluster_id):
 @pytest.mark.author("mbukatov@redhat.com")
 @pytest.mark.gluster
 @pytest.mark.negative
-@pytest.mark.testready
 def test_cluster_import_fail_with_one_nodeagent_down(
         valid_session_credentials,
         cluster_reuse,

--- a/usmqe_tests/api/gluster/test_gluster_cluster.py
+++ b/usmqe_tests/api/gluster/test_gluster_cluster.py
@@ -169,7 +169,7 @@ def test_cluster_import_fail_with_one_nodeagent_down(
     Negative import gluster cluster when node agent is not running on one
     storage machine. Import should fail in such case.
     """
-    api = glusterapi.TendrlApiGluster(auth=valid_session_credentials)
+    tendrl = glusterapi.TendrlApiGluster(auth=valid_session_credentials)
 
     # this test can't go on if we don't have proper cluster id at this point
     assert cluster_reuse["cluster_id"] is not None
@@ -185,7 +185,7 @@ def test_cluster_import_fail_with_one_nodeagent_down(
     """
     retry_num = 12
     for i in range(retry_num):
-        cluster = api.get_cluster(cluster_reuse["cluster_id"])
+        cluster = tendrl.get_cluster(cluster_reuse["cluster_id"])
         if len(cluster["nodes"]) == len(valid_trusted_pool_reuse):
             LOGGER.debug("cluster (via tendrl API) has expected number of nodes")
             break
@@ -205,10 +205,10 @@ def test_cluster_import_fail_with_one_nodeagent_down(
       The job starts and finishes with failed status after some time.
     """
     LOGGER.info("starting import cluster job")
-    import_job = api.import_cluster(cluster_reuse["cluster_id"])
+    import_job = tendrl.import_cluster(cluster_reuse["cluster_id"])
     LOGGER.info(
         "import (job id {}) submited, waiting for completion".format(import_job["job_id"]))
-    api.wait_for_job_status(import_job["job_id"], status="failed")
+    tendrl.wait_for_job_status(import_job["job_id"], status="failed")
 
     """
     :step:
@@ -217,12 +217,12 @@ def test_cluster_import_fail_with_one_nodeagent_down(
     :result:
       There is exactly one such cluster, and it's not managed (aka not imported).
     """
-    integration_id = api.get_job_attribute(
+    integration_id = tendrl.get_job_attribute(
         job_id=import_job["job_id"],
         attribute="TendrlContext.integration_id",
         section="parameters")
     LOGGER.debug("integration_id: %s" % integration_id)
-    clusters = [x for x in api.get_cluster_list() if x["integration_id"] == integration_id]
+    clusters = [x for x in tendrl.get_cluster_list() if x["integration_id"] == integration_id]
     pytest.check(
         len(clusters) == 1,
         "Job list integration_id '{}' should be "

--- a/usmqe_tests/api/gluster/test_gluster_cluster.py
+++ b/usmqe_tests/api/gluster/test_gluster_cluster.py
@@ -160,14 +160,12 @@ def test_cluster_import_invalid_uuid(valid_session_credentials, cluster_id):
 @pytest.mark.author("mbukatov@redhat.com")
 @pytest.mark.gluster
 @pytest.mark.negative
-@pytest.mark.ansible_playbook_setup("test_setup.tendrl_nodeagent_stopped_on_one_node.yml")
-@pytest.mark.ansible_playbook_teardown("test_teardown.tendrl_nodeagent_stopped_on_one_node.yml")
 @pytest.mark.testready
 def test_cluster_import_fail_with_one_nodeagent_down(
         valid_session_credentials,
         cluster_reuse,
         valid_trusted_pool_reuse,
-        ansible_playbook):
+        importfail_setup_nodeagent_stopped_on_one_node):
     """
     Negative import gluster cluster when node agent is not running on one
     storage machine. Import should fail in such case.


### PR DESCRIPTION
This is the more convenient case, with Tendrl being aware of the machine, but then the node agent is stopped. The test setup is implemented in new fixture using https://github.com/usmqe/usmqe-setup/pull/245